### PR TITLE
docs(job): correct job-runner concurrency model in architecture docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ The frontend is **not** served from a runtime path: its build output (`frontend/
 
 ## Architecture
 
-Axum HTTP layer (`src/web/`) → `Auth` extractor → handlers → `Storage` wrapper / SeaORM entities. A background job runner (`src/job/`) processes file classification through a multi-pass plugin pipeline (`src/plugin/` + `plugins/*` cdylib crates, loaded via `byteburrow-plugin-api`'s FFI contract), running concurrently with the web server via `tokio::select!`.
+Axum HTTP layer (`src/web/`) → `Auth` extractor → handlers → `Storage` wrapper / SeaORM entities. A background job runner (`src/job/`) runs on its own OS thread with a dedicated low-priority (`nice 10`) multi-threaded Tokio runtime; it processes file classification through a multi-pass plugin pipeline (`src/plugin/` + `plugins/*` cdylib crates, loaded via `byteburrow-plugin-api`'s FFI contract). On the main runtime, only the inotify watcher and the web server are arms of the `tokio::select!`.
 
 Full module map, request flow, OpenAPI tag grouping, and key patterns (auth, DB access, error responses, plugin system, background jobs): **[docs/architecture.md](docs/architecture.md)**.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,7 +30,8 @@ Deep reference for ByteBurrow's module layout, request flow, and key patterns. S
 - **`src/job/`**: Background job runner
   - Asynchronous job processing with configurable concurrency (based on CPU cores), running on a dedicated low-priority Tokio runtime
   - Single job type `Job::ProcessFile { storage_id, path, mode }`, where `ProcessMode` is `Auto` (check-then-classify, respects `skip_plugins`), `ForceClassify` (re-run plugins regardless of change), or `HashOnly` (recalculate hash only, never runs plugins)
-  - Runs concurrently with the web server via `tokio::select!`
+  - Runs on a **dedicated OS thread** that owns its own multi-threaded Tokio runtime, with every worker thread set to `nice 10` so the OS scheduler always prefers the web server (main runtime) over background work
+  - Only the inotify watcher and the web server are the two arms of the main runtime's `tokio::select!`; the job runner is **not** an arm of that select — it blocks on its own thread, draining jobs from the channel on its low-priority runtime until the sender side is dropped
 
 - **`src/migration/`**: Database schema migrations
   - SeaORM migration system
@@ -72,7 +73,7 @@ Deep reference for ByteBurrow's module layout, request flow, and key patterns. S
 ## Application Flow
 
 1. **Startup**: `src/bin/byteburrow.rs` initializes tracing, loads config, connects to database, runs pending migrations, loads plugins
-2. **Concurrent execution**: job runner and web server run in parallel via `tokio::select!`
+2. **Concurrent execution**: the job runner is spawned on its own OS thread with a dedicated low-priority (`nice 10`) multi-threaded Tokio runtime (`src/job/mod.rs`); the main Tokio runtime then runs the inotify watcher and web server concurrently via `tokio::select!`
 3. **Request handling**: Axum router → Auth extractor → Handler → Database/Filesystem → Response
 4. **State management**: `AppState` contains DB connection, config, Jinja templates, and job sender
 5. **Background jobs**: handlers can enqueue jobs via `JobSender` for async processing


### PR DESCRIPTION
## What

Corrects the job-runner concurrency model description in the architecture docs, which previously claimed the job runner runs "concurrently with the web server via `tokio::select!`".

## Why

Closes #13 (audit finding C4). The actual implementation (`src/job/mod.rs`, spawned in `src/bin/byteburrow.rs`) runs the `JobRunner` on a **dedicated OS thread with its own multi-threaded Tokio runtime at `nice 10`** — it is *not* an arm of the main runtime's `tokio::select!`. Only the inotify watcher and the web server are. The old wording misled anyone reasoning about threading, scheduling priority, or shutdown ordering.

## Changes

Three stale locations corrected to match the code:

- `docs/architecture.md` — `src/job/` section: replaced the `tokio::select!` claim with two accurate bullets (dedicated OS thread + `nice 10` runtime; only inotify + web are the `select!` arms).
- `docs/architecture.md` — Application Flow #2: job runner spawns on its own low-priority thread/runtime; main runtime runs inotify + web via `select!`.
- `CLAUDE.md` — the same misdescription was duplicated in the Architecture summary; fixed per the CLAUDE.md maintenance rule.

Also grepped `docs/adr/` — no other stale references to the concurrency model.

**Diffstat:** `2 files changed, 4 insertions(+), 3 deletions(-)` — documentation only, no code or behavior change.